### PR TITLE
fix: Nested translations aren't translated

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -12,8 +12,6 @@ export const hasPhpTranslations = (folderPath: string): boolean => {
       .sort()
 
     for (const folder of folders) {
-      const lang = {}
-
       const files = fs.readdirSync(folderPath + path.sep + folder).filter((file) => /\.php$/.test(file))
 
       if (files.length > 0) {
@@ -35,32 +33,7 @@ export const parseAll = (folderPath: string): { name: string; path: string }[] =
 
   const data = []
   for (const folder of folders) {
-    const lang = {}
-
-    fs.readdirSync(folderPath + path.sep + folder)
-      .sort()
-      .forEach((langFolderItem) => {
-        const langFolderPath = folderPath + path.sep + folder
-        const langFolderItemPath = langFolderPath + path.sep + langFolderItem
-
-        if (fs.statSync(langFolderItemPath).isDirectory()) {
-          // Lang sub folder
-          const subFolderFileKey = langFolderItem.replace(/\.\w+$/, '')
-          lang[subFolderFileKey] = {}
-
-          fs.readdirSync(langFolderItemPath)
-            .filter((file) => !fs.statSync(langFolderItemPath + path.sep + file).isDirectory())
-            .sort()
-            .forEach((file) => {
-              lang[subFolderFileKey][file.replace(/\.\w+$/, '')] = parse(
-                fs.readFileSync(langFolderItemPath + path.sep + file).toString()
-              )
-            })
-        } else {
-          // Lang file
-          lang[langFolderItem.replace(/\.\w+$/, '')] = parse(fs.readFileSync(langFolderItemPath).toString())
-        }
-      })
+    const lang = readThroughDir(folderPath + path.sep + folder)
 
     data.push({
       folder,
@@ -146,4 +119,22 @@ export const reset = (folderPath) => {
     .forEach((file) => {
       fs.unlinkSync(folderPath + file)
     })
+}
+
+export const readThroughDir = (dir) => {
+  const data = {}
+
+  fs.readdirSync(dir).forEach((file) => {
+    const absoluteFile = dir + path.sep + file
+
+    if (fs.statSync(absoluteFile).isDirectory()) {
+      const subFolderFileKey = file.replace(/\.\w+$/, '')
+
+      data[subFolderFileKey] = readThroughDir(absoluteFile)
+    } else {
+      data[file.replace(/\.\w+$/, '')] = parse(fs.readFileSync(absoluteFile).toString())
+    }
+  })
+
+  return data
 }

--- a/src/mix.ts
+++ b/src/mix.ts
@@ -39,7 +39,7 @@ mix.extend(
       if (hasPhpTranslations(this.langPath)) {
         config.plugins.push(
           new EnvironmentPlugin({
-            LARAVEL_VUE_I18N_HAS_PHP: true
+            VITE_LARAVEL_REACT_I18N_HAS_PHP: true
           })
         )
       }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -126,6 +126,8 @@ export function LaravelReactI18nProvider({
    * Get the translation for the given key and watch for any changes.
    */
   function wTrans(key: string, replacements: ReplacementsInterface = {}): string {
+    key = key.replace(/\//g, '.')
+
     if (!activeMessages[key]) {
       activeMessages[key] = key
     }

--- a/test/create-some-test.test.ts
+++ b/test/create-some-test.test.ts
@@ -1,3 +1,0 @@
-it('create some test', () => {
-//
-});

--- a/test/fixtures/lang/en/nested/cars/car.php
+++ b/test/fixtures/lang/en/nested/cars/car.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'car' => 'Car|Cars',
+    'is_electric' => 'Electric',
+    'charge_speed' => 'Charge speed',
+    'foo' => [
+        'level1' => [
+            'level2' => 'barpt'
+        ]
+    ],
+];

--- a/test/fixtures/lang/pt/nested/cars/car.php
+++ b/test/fixtures/lang/pt/nested/cars/car.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'is_electric' => 'É elétrico?',
+    'foo' => [
+        'level1' => [
+            'level2' => 'barpt',
+        ]
+    ]
+];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import { parseAll, parse, hasPhpTranslations, reset } from '../src/loader';
+beforeEach(() => reset(__dirname + '/fixtures/lang/'));
+
+it('creates a file for each lang', () => {
+    const files = parseAll(__dirname + '/fixtures/lang/');
+    expect(files.length).toBe(3);
+    expect(files[0].name).toBe('php_en.json');
+    expect(files[1].name).toBe('php_fr.json');
+    expect(files[2].name).toBe('php_pt.json');
+    const langEn = JSON.parse(fs.readFileSync(files[0].path).toString());
+    expect(langEn['auth.failed']).toBe('These credentials do not match our records.');
+    expect(langEn['auth.foo.level1.level2']).toBe('baren');
+    expect(langEn['auth.multiline']).toBe('Lorem ipsum dolor sit amet.');
+    const langPt = JSON.parse(fs.readFileSync(files[2].path).toString());
+    expect(langPt['auth.failed']).toBe('As credenciais indicadas não coincidem com as registadas no sistema.');
+    expect(langPt['auth.foo.level1.level2']).toBe('barpt');
+});
+
+it('includes .php lang file in subdirectory in .json', () => {
+    const files = parseAll(__dirname + '/fixtures/lang/');
+    const langEn = JSON.parse(fs.readFileSync(files[0].path).toString());
+    expect(langEn['domain.user.sub_dir_support_is_amazing']).toBe('Subdirectory support is amazing');
+    expect(langEn['domain.car.is_electric']).toBe('Electric');
+    expect(langEn['domain.car.foo.level1.level2']).toBe('barpt');
+});
+
+it('includes .php lang file in nested subdirectory in .json', () => {
+    const files = parseAll(__dirname + '/fixtures/lang/');
+    const langEn = JSON.parse(fs.readFileSync(files[0].path).toString())
+
+    expect(langEn['nested.cars.car.is_electric']).toBe('Electric');
+    expect(langEn['nested.cars.car.foo.level1.level2']).toBe('barpt');
+})
+
+it('transforms .php lang to .json', () => {
+    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+
+    expect(lang['failed']).toBe('These credentials do not match our records.');
+});
+
+it('transform nested .php lang files to .json', () => {
+    const langPt = parse(fs.readFileSync(__dirname + '/fixtures/lang/pt/auth.php').toString());
+    expect(langPt['foo.level1.level2']).toBe('barpt');
+    const langEn = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+    expect(langEn['foo.level1.level2']).toBe('baren');
+});
+
+it('transforms simple index array to .json', () => {
+    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+    expect(lang['arr.0']).toBe('foo');
+    expect(lang['arr.1']).toBe('bar');
+});
+
+it('checks if there is .php translations', () => {
+    expect(hasPhpTranslations(__dirname + '/fixtures/lang/')).toBe(true);
+    expect(hasPhpTranslations(__dirname + '/fixtures/wronglangfolder/')).toBe(false);
+});


### PR DESCRIPTION
This pull request fixes the same problem in this repo as described [here](https://github.com/xiCO2k/laravel-vue-i18n/issues/84), and based on [this pull request](https://github.com/xiCO2k/laravel-vue-i18n/pull/88).