### PR TITLE
Replacement with component availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ export default function Component() {
 
 ### `t(key: string, replacements?: {[key: string]: string | number})`
 
-The `t()` method can translate a given message.
+The `t()` method can translate a given message into an array.
 
 `lang/pt.json:`
 ```json
@@ -193,10 +193,12 @@ The `t()` method can translate a given message.
 ...
 const { t } = useLaravelReactI18n();
 
-t('Welcome!'); // Bem-vindo!
-t('Welcome, :name!', { name: 'Francisco' }); // Bem-vindo Francisco!
-t('Welcome, :NAME!', { name: 'Francisco' }); // Bem-vindo FRANCISCO!
-t('Some untranslated'); // Some untranslated
+t('Welcome!'); // ["Bem-vindo!"]
+t('Welcome, :name!', { name: 'Francisco' }); // ["Bem-vindo, ", "Francisco", "!"]
+t('Welcome, :name!', { name: <a href="#">Francisco</a> }); // ["Bem-vindo, ", <a href="#">Francisco</a>, "!"]
+t('Welcome, :NAME!', { name: <a href="#">Francisco</a> }); // ["Bem-vindo, ", <a href="#">Francisco</a>, "!"]
+t('Welcome, :NAME!', { name: 'Francisco' }); // ["Bem-vindo, ", "FRANCISCO", "!"]
+t('Some untranslated'); // ["Some untranslated"]
 ...
 ```
 

--- a/__tests__/utils/replacer.test.ts
+++ b/__tests__/utils/replacer.test.ts
@@ -1,38 +1,67 @@
+import React from "react"
 import replacer from '../../src/utils/replacer';
 
 it.each([
-  ['some text', ':replace', 'some text'],
-  ['some  text', ':replace', 'some  text'],
-  [' some text ', ' :replace ', 'some text'],
-  [' some text ', ':replace', ' some text '],
-  ['\nsome text', '\n:replace', 'some text'],
-  ['some\ntext', ':replace', 'some\ntext'],
+  [['some text'], ':replace', 'some text'],
+  [['some  text'], ':replace', 'some  text'],
+  [[' ', 'some text', ' '], ' :replace ', 'some text'],
+  [['some text'], ':replace', 'some text'],
+  [['\n', 'some text'], '\n:replace', 'some text'],
+  [['some text'], ':replace', 'some text'],
 
-  ['"some text"', '":replace"', 'some text'],
-  ['<div>some text</div>', '<div>:replace</div>', 'some text'],
+  [['"', 'some text', '"'], '":replace"', 'some text'],
+  [['<div>', 'some text', '</div>'], '<div>:replace</div>', 'some text'],
 
-  ['some text', ':replace', 'some text'],
-  ['Some text', ':Replace', 'some text'],
-  ['SOME TEXT', ':REPLACE', 'some text'],
+  [['some text'], ':replace', 'some text'],
+  [['Some text'], ':Replace', 'some text'],
+  [['SOME TEXT'], ':REPLACE', 'some text'],
 
-  ['Lorem Ipsum some text', 'Lorem Ipsum :replace', 'some text'],
-  ['some text Lorem Ipsum', ':replace Lorem Ipsum', 'some text'],
-  ['Lorem Ipsum some text Lorem Ipsum', 'Lorem Ipsum :replace Lorem Ipsum', 'some text'],
+  [['Lorem Ipsum ', 'some text'], 'Lorem Ipsum :replace', 'some text'],
+  [['some text', ' Lorem Ipsum'], ':replace Lorem Ipsum', 'some text'],
+  [['Lorem Ipsum ', 'some text', ' Lorem Ipsum'], 'Lorem Ipsum :replace Lorem Ipsum', 'some text'],
 
-  ['some text some text', ':replace :replace', 'some text'],
-  [':anyReplace', ':anyReplace', 'some text']
+  [['some text', ' ', 'some text'], ':replace :replace', 'some text'],
+  [[':anyReplace'], ':anyReplace', 'some text']
 ])('replacer', (expected, message, replace) => {
-  expect(replacer(message, { replace })).toBe(expected);
+  expect(replacer(message, { replace })).toStrictEqual(expected);
 });
 
 test('Sentence replace', () => {
-  const expected =
-    'It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.';
+  const expected = [
+    'It has survived not only ',
+    'five', // count
+    ' centuries, but also the leap into ',
+    'electronic', // epocheType
+    ' typesetting, remaining ',
+    'essentially', // remaining
+    ' unchanged.'
+  ];
 
-  const message =
-    'It has survived not only :count centuries, but also the leap into :epochType typesetting, remaining :remaining unchanged.';
+  const message = 'It has survived not only :count centuries, but also the leap into :epochType typesetting, remaining :remaining unchanged.';
 
   const replacements = { count: 'five', epochType: 'electronic', remaining: 'essentially' };
 
-  expect(replacer(message, replacements)).toBe(expected);
+  expect(replacer(message, replacements)).toStrictEqual(expected);
+});
+
+test('Components replace', () => {
+  const linkElement = React.createElement('a', { href: 'https://example.com', key: 'link' }, 'here');
+  const boldElement = React.createElement('b', { key: 'bold' }, 'important');
+
+  const expected = [
+    'Click ',
+    linkElement,
+    ' to visit our website. This is ',
+    boldElement,
+    '.'
+  ];
+
+  const message = 'Click :link to visit our website. This is :bold.';
+
+  const replacements = {
+    link: linkElement,
+    bold: boldElement
+  };
+
+  expect(replacer(message, replacements)).toStrictEqual(expected);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "laravel-react-i18n",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "laravel-react-i18n",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "php-array-reader": "^2.1.2",
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   },
   "dependencies": {
     "php-array-reader": "^2.1.2",
-    "react": "^18.2.0"
+    "react": "^18.3.1"
   }
 }

--- a/src/interfaces/context.ts
+++ b/src/interfaces/context.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import ReplacementsInterface from './replacements';
 
 /**
@@ -9,6 +10,6 @@ export default interface ContextInterface<T extends string = any> {
   isLocale: (locale: string) => boolean;
   loading: boolean;
   setLocale: (locale: string) => void;
-  t: (key: T, replacements?: ReplacementsInterface) => string;
-  tChoice: (key: T, number: number, replacements?: ReplacementsInterface) => string;
+  t: (key: T, replacements?: ReplacementsInterface) => ReactNode;
+  tChoice: (key: T, number: number, replacements?: ReplacementsInterface) => ReactNode;
 }

--- a/src/interfaces/replacements.ts
+++ b/src/interfaces/replacements.ts
@@ -1,6 +1,8 @@
+import { ReactNode } from "react";
+
 /**
  *
  */
 export default interface ReplacementsInterface {
-  [key: string]: string | number;
+  [key: string]: ReactNode;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -170,8 +170,8 @@ export default function LaravelReactI18nProvider({ children, ssr, ...currentOpti
     const locale = isLocale(options.locale) ? options.locale : options.fallbackLocale;
 
     return replacer(pluralization(message, number, locale), {
+      count: number.toString(),
       ...replacements,
-      count: number.toString()
     });
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import { createElement, useEffect, useState } from 'react';
+import { createElement, ReactNode, useEffect, useState } from 'react';
 
 import { Context } from './context';
 import type DefaultOptionsInterface from './interfaces/default-options';
@@ -135,11 +135,10 @@ export default function LaravelReactI18nProvider({ children, ssr, ...currentOpti
   }
 
   /**
-   * Get the translation for the given key.
+   * Get the raw translation for the given key (with no placeholders).
    */
-  function t(key: string, replacements: ReplacementsInterface = {}): string {
+  function _translate(key: string) {
     const { locale, fallbackLocale, prevLocale } = options;
-
     let message = translation.get(fallbackLocale)?.[key] ? translation.get(fallbackLocale)[key] : key;
 
     if (isLocale(locale)) {
@@ -151,6 +150,14 @@ export default function LaravelReactI18nProvider({ children, ssr, ...currentOpti
         message = translation.get(fallbackLocale)[key];
       }
     }
+    return message;
+  }
+
+  /**
+   * Get the translation for the given key.
+   */
+  function t(key: string, replacements: ReplacementsInterface = {}): ReactNode {
+    const message = _translate(key);
 
     return replacer(message, replacements);
   }
@@ -158,8 +165,8 @@ export default function LaravelReactI18nProvider({ children, ssr, ...currentOpti
   /**
    * Translates the given message based on a count.
    */
-  function tChoice(key: string, number: number, replacements: ReplacementsInterface = {}): string {
-    const message = t(key, replacements);
+  function tChoice(key: string, number: number, replacements: ReplacementsInterface = {}): ReactNode {
+    const message = _translate(key);
     const locale = isLocale(options.locale) ? options.locale : options.fallbackLocale;
 
     return replacer(pluralization(message, number, locale), {


### PR DESCRIPTION
I've tried my best to make replacement with components available as strings and numbers are.
maybe that needs some more work on the `tChoice` function in case someone want :count to be a custom component using `pluralization` cause it takes a number which is :count in this case.